### PR TITLE
React 18

### DIFF
--- a/es/Modal.js
+++ b/es/Modal.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = void 0;
+exports.default = exports.ModalContext = void 0;
 
 var _classnames = _interopRequireDefault(require("classnames"));
 
@@ -15,17 +15,17 @@ var _inDOM = _interopRequireDefault(require("dom-helpers/util/inDOM"));
 
 var _scrollbarSize = _interopRequireDefault(require("dom-helpers/util/scrollbarSize"));
 
-var _react = _interopRequireDefault(require("react"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _elementType = _interopRequireDefault(require("prop-types-extra/lib/elementType"));
+
+var _react = _interopRequireDefault(require("react"));
 
 var _reactDom = _interopRequireDefault(require("react-dom"));
 
 var _Modal = _interopRequireDefault(require("react-overlays/lib/Modal"));
 
 var _isOverflowing = _interopRequireDefault(require("react-overlays/lib/utils/isOverflowing"));
-
-var _elementType = _interopRequireDefault(require("prop-types-extra/lib/elementType"));
 
 var _Fade = _interopRequireDefault(require("./Fade"));
 
@@ -154,11 +154,6 @@ const defaultProps = { ..._Modal.default.defaultProps,
   animation: true,
   dialogComponentClass: _ModalDialog.default
 };
-const childContextTypes = {
-  $bs_modal: _propTypes.default.shape({
-    onHide: _propTypes.default.func
-  })
-};
 /* eslint-disable no-use-before-define, react/no-multi-comp */
 
 function DialogTransition(props) {
@@ -175,6 +170,12 @@ function BackdropTransition(props) {
 /* eslint-enable no-use-before-define */
 
 
+const ModalContext = _react.default.createContext({
+  onHide: () => {}
+});
+
+exports.ModalContext = ModalContext;
+
 class Modal extends _react.default.Component {
   constructor(props, context) {
     super(props, context);
@@ -185,14 +186,6 @@ class Modal extends _react.default.Component {
     this.setModalRef = this.setModalRef.bind(this);
     this.state = {
       style: {}
-    };
-  }
-
-  getChildContext() {
-    return {
-      $bs_modal: {
-        onHide: this.props.onHide
-      }
     };
   }
 
@@ -265,7 +258,11 @@ class Modal extends _react.default.Component {
     } = this.props;
     const [baseModalProps, dialogProps] = (0, _splitComponentProps.default)(props, _Modal.default);
     const inClassName = show && !animation && 'in';
-    return _react.default.createElement(_Modal.default, _extends({}, baseModalProps, {
+    return _react.default.createElement(ModalContext.Provider, {
+      value: {
+        onHide: this.props.onHide
+      }
+    }, _react.default.createElement(_Modal.default, _extends({}, baseModalProps, {
       ref: this.setModalRef,
       show: show,
       containerClassName: (0, _bootstrapUtils.prefix)(props, 'open'),
@@ -281,14 +278,13 @@ class Modal extends _react.default.Component {
       },
       className: (0, _classnames.default)(className, inClassName),
       onClick: backdrop === true ? this.handleDialogClick : null
-    }), children));
+    }), children)));
   }
 
 }
 
 Modal.propTypes = propTypes;
 Modal.defaultProps = defaultProps;
-Modal.childContextTypes = childContextTypes;
 Modal.Body = _ModalBody.default;
 Modal.Header = _ModalHeader.default;
 Modal.Title = _ModalTitle.default;

--- a/es/ModalHeader.js
+++ b/es/ModalHeader.js
@@ -11,11 +11,13 @@ var _propTypes = _interopRequireDefault(require("prop-types"));
 
 var _react = _interopRequireDefault(require("react"));
 
+var _Modal = require("./Modal");
+
+var _CloseButton = _interopRequireDefault(require("./CloseButton"));
+
 var _bootstrapUtils = require("./utils/bootstrapUtils");
 
 var _createChainedFunction = _interopRequireDefault(require("./utils/createChainedFunction"));
-
-var _CloseButton = _interopRequireDefault(require("./CloseButton"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -46,11 +48,6 @@ const defaultProps = {
   closeLabel: 'Close',
   closeButton: false
 };
-const contextTypes = {
-  $bs_modal: _propTypes.default.shape({
-    onHide: _propTypes.default.func
-  })
-};
 
 class ModalHeader extends _react.default.Component {
   render() {
@@ -62,22 +59,20 @@ class ModalHeader extends _react.default.Component {
       children,
       ...props
     } = this.props;
-    const modal = this.context.$bs_modal;
     const [bsProps, elementProps] = (0, _bootstrapUtils.splitBsProps)(props);
     const classes = (0, _bootstrapUtils.getClassSet)(bsProps);
-    return _react.default.createElement("div", _extends({}, elementProps, {
+    return _react.default.createElement(_Modal.ModalContext.Consumer, null, modal => _react.default.createElement("div", _extends({}, elementProps, {
       className: (0, _classnames.default)(className, classes)
     }), closeButton && _react.default.createElement(_CloseButton.default, {
       label: closeLabel,
       onClick: (0, _createChainedFunction.default)(modal && modal.onHide, onHide)
-    }), children);
+    }), children));
   }
 
 }
 
 ModalHeader.propTypes = propTypes;
 ModalHeader.defaultProps = defaultProps;
-ModalHeader.contextTypes = contextTypes;
 
 var _default = (0, _bootstrapUtils.bsClass)('modal-header', ModalHeader);
 

--- a/es/OverlayTrigger.js
+++ b/es/OverlayTrigger.js
@@ -7,9 +7,9 @@ exports.default = void 0;
 
 var _contains = _interopRequireDefault(require("dom-helpers/query/contains"));
 
-var _react = _interopRequireWildcard(require("react"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _react = _interopRequireWildcard(require("react"));
 
 var _reactDom = _interopRequireDefault(require("react-dom"));
 
@@ -142,6 +142,7 @@ class OverlayTrigger extends _react.default.Component {
 
   componentDidMount() {
     this._mountNode = document.createElement('div');
+    document.body.appendChild(this._mountNode);
     this.renderOverlay();
   }
 
@@ -152,6 +153,7 @@ class OverlayTrigger extends _react.default.Component {
   componentWillUnmount() {
     _reactDom.default.unmountComponentAtNode(this._mountNode);
 
+    document.body.removeChild(this._mountNode);
     this._mountNode = null;
     clearTimeout(this._hoverShowDelay);
     clearTimeout(this._hoverHideDelay);
@@ -251,7 +253,7 @@ class OverlayTrigger extends _react.default.Component {
   }
 
   renderOverlay() {
-    _reactDom.default.unstable_renderSubtreeIntoContainer(this, this._overlay, this._mountNode);
+    _reactDom.default.createPortal(this._overlay, this._mountNode);
   }
 
   render() {

--- a/lib/Modal.js
+++ b/lib/Modal.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.default = void 0;
+exports.default = exports.ModalContext = void 0;
 
 var _classnames = _interopRequireDefault(require("classnames"));
 
@@ -15,17 +15,17 @@ var _inDOM = _interopRequireDefault(require("dom-helpers/util/inDOM"));
 
 var _scrollbarSize = _interopRequireDefault(require("dom-helpers/util/scrollbarSize"));
 
-var _react = _interopRequireDefault(require("react"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _elementType = _interopRequireDefault(require("prop-types-extra/lib/elementType"));
+
+var _react = _interopRequireDefault(require("react"));
 
 var _reactDom = _interopRequireDefault(require("react-dom"));
 
 var _Modal = _interopRequireDefault(require("react-overlays/lib/Modal"));
 
 var _isOverflowing = _interopRequireDefault(require("react-overlays/lib/utils/isOverflowing"));
-
-var _elementType = _interopRequireDefault(require("prop-types-extra/lib/elementType"));
 
 var _Fade = _interopRequireDefault(require("./Fade"));
 
@@ -154,11 +154,6 @@ const defaultProps = { ..._Modal.default.defaultProps,
   animation: true,
   dialogComponentClass: _ModalDialog.default
 };
-const childContextTypes = {
-  $bs_modal: _propTypes.default.shape({
-    onHide: _propTypes.default.func
-  })
-};
 /* eslint-disable no-use-before-define, react/no-multi-comp */
 
 function DialogTransition(props) {
@@ -175,6 +170,12 @@ function BackdropTransition(props) {
 /* eslint-enable no-use-before-define */
 
 
+const ModalContext = _react.default.createContext({
+  onHide: () => {}
+});
+
+exports.ModalContext = ModalContext;
+
 class Modal extends _react.default.Component {
   constructor(props, context) {
     super(props, context);
@@ -185,14 +186,6 @@ class Modal extends _react.default.Component {
     this.setModalRef = this.setModalRef.bind(this);
     this.state = {
       style: {}
-    };
-  }
-
-  getChildContext() {
-    return {
-      $bs_modal: {
-        onHide: this.props.onHide
-      }
     };
   }
 
@@ -265,7 +258,11 @@ class Modal extends _react.default.Component {
     } = this.props;
     const [baseModalProps, dialogProps] = (0, _splitComponentProps.default)(props, _Modal.default);
     const inClassName = show && !animation && 'in';
-    return _react.default.createElement(_Modal.default, _extends({}, baseModalProps, {
+    return _react.default.createElement(ModalContext.Provider, {
+      value: {
+        onHide: this.props.onHide
+      }
+    }, _react.default.createElement(_Modal.default, _extends({}, baseModalProps, {
       ref: this.setModalRef,
       show: show,
       containerClassName: (0, _bootstrapUtils.prefix)(props, 'open'),
@@ -281,14 +278,13 @@ class Modal extends _react.default.Component {
       },
       className: (0, _classnames.default)(className, inClassName),
       onClick: backdrop === true ? this.handleDialogClick : null
-    }), children));
+    }), children)));
   }
 
 }
 
 Modal.propTypes = propTypes;
 Modal.defaultProps = defaultProps;
-Modal.childContextTypes = childContextTypes;
 Modal.Body = _ModalBody.default;
 Modal.Header = _ModalHeader.default;
 Modal.Title = _ModalTitle.default;
@@ -300,4 +296,3 @@ Modal.BACKDROP_TRANSITION_DURATION = 150;
 var _default = (0, _bootstrapUtils.bsClass)('modal', (0, _bootstrapUtils.bsSizes)([_StyleConfig.Size.LARGE, _StyleConfig.Size.SMALL], Modal));
 
 exports.default = _default;
-module.exports = exports["default"];

--- a/lib/ModalHeader.js
+++ b/lib/ModalHeader.js
@@ -11,11 +11,13 @@ var _propTypes = _interopRequireDefault(require("prop-types"));
 
 var _react = _interopRequireDefault(require("react"));
 
+var _Modal = require("./Modal");
+
+var _CloseButton = _interopRequireDefault(require("./CloseButton"));
+
 var _bootstrapUtils = require("./utils/bootstrapUtils");
 
 var _createChainedFunction = _interopRequireDefault(require("./utils/createChainedFunction"));
-
-var _CloseButton = _interopRequireDefault(require("./CloseButton"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -46,11 +48,6 @@ const defaultProps = {
   closeLabel: 'Close',
   closeButton: false
 };
-const contextTypes = {
-  $bs_modal: _propTypes.default.shape({
-    onHide: _propTypes.default.func
-  })
-};
 
 class ModalHeader extends _react.default.Component {
   render() {
@@ -62,22 +59,20 @@ class ModalHeader extends _react.default.Component {
       children,
       ...props
     } = this.props;
-    const modal = this.context.$bs_modal;
     const [bsProps, elementProps] = (0, _bootstrapUtils.splitBsProps)(props);
     const classes = (0, _bootstrapUtils.getClassSet)(bsProps);
-    return _react.default.createElement("div", _extends({}, elementProps, {
+    return _react.default.createElement(_Modal.ModalContext.Consumer, null, modal => _react.default.createElement("div", _extends({}, elementProps, {
       className: (0, _classnames.default)(className, classes)
     }), closeButton && _react.default.createElement(_CloseButton.default, {
       label: closeLabel,
       onClick: (0, _createChainedFunction.default)(modal && modal.onHide, onHide)
-    }), children);
+    }), children));
   }
 
 }
 
 ModalHeader.propTypes = propTypes;
 ModalHeader.defaultProps = defaultProps;
-ModalHeader.contextTypes = contextTypes;
 
 var _default = (0, _bootstrapUtils.bsClass)('modal-header', ModalHeader);
 

--- a/lib/OverlayTrigger.js
+++ b/lib/OverlayTrigger.js
@@ -7,9 +7,9 @@ exports.default = void 0;
 
 var _contains = _interopRequireDefault(require("dom-helpers/query/contains"));
 
-var _react = _interopRequireWildcard(require("react"));
-
 var _propTypes = _interopRequireDefault(require("prop-types"));
+
+var _react = _interopRequireWildcard(require("react"));
 
 var _reactDom = _interopRequireDefault(require("react-dom"));
 
@@ -142,6 +142,7 @@ class OverlayTrigger extends _react.default.Component {
 
   componentDidMount() {
     this._mountNode = document.createElement('div');
+    document.body.appendChild(this._mountNode);
     this.renderOverlay();
   }
 
@@ -152,6 +153,7 @@ class OverlayTrigger extends _react.default.Component {
   componentWillUnmount() {
     _reactDom.default.unmountComponentAtNode(this._mountNode);
 
+    document.body.removeChild(this._mountNode);
     this._mountNode = null;
     clearTimeout(this._hoverShowDelay);
     clearTimeout(this._hoverHideDelay);
@@ -251,7 +253,7 @@ class OverlayTrigger extends _react.default.Component {
   }
 
   renderOverlay() {
-    _reactDom.default.unstable_renderSubtreeIntoContainer(this, this._overlay, this._mountNode);
+    _reactDom.default.createPortal(this._overlay, this._mountNode);
   }
 
   render() {

--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -1,10 +1,11 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { ModalContext } from './Modal';
 
+import CloseButton from './CloseButton';
 import { bsClass, getClassSet, splitBsProps } from './utils/bootstrapUtils';
 import createChainedFunction from './utils/createChainedFunction';
-import CloseButton from './CloseButton';
 
 // TODO: `aria-label` should be `closeLabel`.
 
@@ -34,12 +35,6 @@ const defaultProps = {
   closeButton: false
 };
 
-const contextTypes = {
-  $bs_modal: PropTypes.shape({
-    onHide: PropTypes.func
-  })
-};
-
 class ModalHeader extends React.Component {
   render() {
     const {
@@ -51,29 +46,30 @@ class ModalHeader extends React.Component {
       ...props
     } = this.props;
 
-    const modal = this.context.$bs_modal;
-
     const [bsProps, elementProps] = splitBsProps(props);
 
     const classes = getClassSet(bsProps);
 
     return (
-      <div {...elementProps} className={classNames(className, classes)}>
-        {closeButton && (
-          <CloseButton
-            label={closeLabel}
-            onClick={createChainedFunction(modal && modal.onHide, onHide)}
-          />
-        )}
+      <ModalContext.Consumer>
+        {modal => (
+          <div {...elementProps} className={classNames(className, classes)}>
+            {closeButton && (
+              <CloseButton
+                label={closeLabel}
+                onClick={createChainedFunction(modal && modal.onHide, onHide)}
+              />
+            )}
 
-        {children}
-      </div>
+            {children}
+          </div>
+        )}
+      </ModalContext.Consumer>
     );
   }
 }
 
 ModalHeader.propTypes = propTypes;
 ModalHeader.defaultProps = defaultProps;
-ModalHeader.contextTypes = contextTypes;
 
 export default bsClass('modal-header', ModalHeader);

--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -1,6 +1,6 @@
 import contains from 'dom-helpers/query/contains';
-import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
+import React, { cloneElement } from 'react';
 import ReactDOM from 'react-dom';
 import warning from 'warning';
 
@@ -121,6 +121,7 @@ class OverlayTrigger extends React.Component {
 
   componentDidMount() {
     this._mountNode = document.createElement('div');
+    document.body.appendChild(this._mountNode);
     this.renderOverlay();
   }
 
@@ -130,6 +131,7 @@ class OverlayTrigger extends React.Component {
 
   componentWillUnmount() {
     ReactDOM.unmountComponentAtNode(this._mountNode);
+    document.body.removeChild(this._mountNode);
     this._mountNode = null;
 
     clearTimeout(this._hoverShowDelay);
@@ -233,11 +235,7 @@ class OverlayTrigger extends React.Component {
   }
 
   renderOverlay() {
-    ReactDOM.unstable_renderSubtreeIntoContainer(
-      this,
-      this._overlay,
-      this._mountNode
-    );
+    ReactDOM.createPortal(this._overlay, this._mountNode);
   }
 
   render() {


### PR DESCRIPTION
Upgrade react-bootstrap to React 18.

Fairly small changes here:

* Remove use of deprecated `getChildContext` method, replace with modern Context API.
* Remove use of deprecated `unstable_renderSubtreeIntoContainer` method, replace with modern Portal API.

Both of these needed to be upgraded to use React 18, because otherwise they cause any tree that renders them to fall back to React 17.

I also considered upgrading `react-bootstrap` in Gem, but it's gone through so many breaking changes that I was worried I would silently break something.

## Testing

Tried to use `yarn link` to test, as it seems that people did in the past, but it didn't work! It seems that the behavior was changed in yarn 2.0. Had to use `yalc` instead, which worked fine. Was able to observe that things continued to work fine. In Gem + React 18, the errors about falling back to React 17 disappeared.