### PR TITLE
Fix OverlayTrigger createPortal usage

### DIFF
--- a/es/OverlayTrigger.js
+++ b/es/OverlayTrigger.js
@@ -143,11 +143,6 @@ class OverlayTrigger extends _react.default.Component {
   componentDidMount() {
     this._mountNode = document.createElement('div');
     document.body.appendChild(this._mountNode);
-    this.renderOverlay();
-  }
-
-  componentDidUpdate() {
-    this.renderOverlay();
   }
 
   componentWillUnmount() {
@@ -253,7 +248,7 @@ class OverlayTrigger extends _react.default.Component {
   }
 
   renderOverlay() {
-    _reactDom.default.createPortal(this._overlay, this._mountNode);
+    return _reactDom.default.createPortal(this._overlay, this._mountNode);
   }
 
   render() {
@@ -302,7 +297,7 @@ class OverlayTrigger extends _react.default.Component {
     }
 
     this._overlay = this.makeOverlay(overlay, props);
-    return (0, _react.cloneElement)(child, triggerProps);
+    return _react.default.createElement(_react.default.Fragment, null, (0, _react.cloneElement)(child, triggerProps), this.state.show && this.renderOverlay());
   }
 
 }

--- a/lib/OverlayTrigger.js
+++ b/lib/OverlayTrigger.js
@@ -143,11 +143,6 @@ class OverlayTrigger extends _react.default.Component {
   componentDidMount() {
     this._mountNode = document.createElement('div');
     document.body.appendChild(this._mountNode);
-    this.renderOverlay();
-  }
-
-  componentDidUpdate() {
-    this.renderOverlay();
   }
 
   componentWillUnmount() {
@@ -253,7 +248,7 @@ class OverlayTrigger extends _react.default.Component {
   }
 
   renderOverlay() {
-    _reactDom.default.createPortal(this._overlay, this._mountNode);
+    return _reactDom.default.createPortal(this._overlay, this._mountNode);
   }
 
   render() {
@@ -302,7 +297,7 @@ class OverlayTrigger extends _react.default.Component {
     }
 
     this._overlay = this.makeOverlay(overlay, props);
-    return (0, _react.cloneElement)(child, triggerProps);
+    return _react.default.createElement(_react.default.Fragment, null, (0, _react.cloneElement)(child, triggerProps), this.state.show && this.renderOverlay());
   }
 
 }

--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -122,11 +122,6 @@ class OverlayTrigger extends React.Component {
   componentDidMount() {
     this._mountNode = document.createElement('div');
     document.body.appendChild(this._mountNode);
-    this.renderOverlay();
-  }
-
-  componentDidUpdate() {
-    this.renderOverlay();
   }
 
   componentWillUnmount() {
@@ -235,7 +230,7 @@ class OverlayTrigger extends React.Component {
   }
 
   renderOverlay() {
-    ReactDOM.createPortal(this._overlay, this._mountNode);
+    return ReactDOM.createPortal(this._overlay, this._mountNode);
   }
 
   render() {
@@ -312,7 +307,12 @@ class OverlayTrigger extends React.Component {
 
     this._overlay = this.makeOverlay(overlay, props);
 
-    return cloneElement(child, triggerProps);
+    return (
+      <>
+        {cloneElement(child, triggerProps)}
+        {this.state.show && this.renderOverlay()}
+      </>
+    );
   }
 }
 


### PR DESCRIPTION
It seems like tooltips that rely on react-bootstrap broke a few weeks ago from https://github.com/zensourcer/react-bootstrap/pull/2.

Two example bugs:
- https://app.asana.com/0/1130275165571676/1208241558512235/f
- https://app.asana.com/0/1130275165571676/1208335787581663/f

Turns out `createPortal` doesn't render nodes, and instead returns a React node that you need to render: https://react.dev/reference/react-dom/createPortal

Test Plan:

- replaced `package.json` SHA with this diff's SHA
- ran `make install`
- saw `<DefaultTooltip>s` that were broken work